### PR TITLE
fix: service base tenant context changed from IUserApp to ITenanApp.

### DIFF
--- a/src/common/services/ServiceBaseTenant.ts
+++ b/src/common/services/ServiceBaseTenant.ts
@@ -1,6 +1,6 @@
 import { ServiceBase } from "./ServiceBase";
 import { IBaseTable } from "../interfaces/IBaseTable";
-import { IUserApp } from "../interfaces/IContextApp";
+import { ITenantApp } from "../interfaces/IContextApp";
 import { UtilTenantScope } from "../utils/UtilTenantScope";
 import { type InferInsertModel } from "drizzle-orm";
 import { type SelectedFields, type PgColumn } from "drizzle-orm/pg-core";
@@ -15,14 +15,14 @@ export abstract class ServiceBaseTenant<
       "id" | "tenantId" | "createdAt" | "isDeleted" | "deletedAt"
     >
   >,
-> extends ServiceBase<TTable, TId, IUserApp, TInsertData> {
-  async create(c: IUserApp, data: TInsertData) {
+> extends ServiceBase<TTable, TId, ITenantApp, TInsertData> {
+  async create(c: ITenantApp, data: TInsertData) {
     return await UtilTenantScope.tenantScope(c, async (tx) => {
       const payload = {
         ...(data as object),
         tenantId: c.tenantId,
       } as unknown as Parameters<
-        ServiceBase<TTable, TId, IUserApp, TInsertData>["create"]
+        ServiceBase<TTable, TId, ITenantApp, TInsertData>["create"]
       >[1];
 
       return await super.create({ ...c, db: tx }, payload);
@@ -30,10 +30,10 @@ export abstract class ServiceBaseTenant<
   }
 
   async update(
-    c: IUserApp,
+    c: ITenantApp,
     id: TId,
     data: Parameters<
-      ServiceBase<TTable, TId, IUserApp, TInsertData>["update"]
+      ServiceBase<TTable, TId, ITenantApp, TInsertData>["update"]
     >[2],
   ) {
     return await UtilTenantScope.tenantScope(c, async (tx) =>
@@ -41,14 +41,14 @@ export abstract class ServiceBaseTenant<
     );
   }
 
-  async remove(c: IUserApp, id: TId) {
+  async remove(c: ITenantApp, id: TId) {
     return await UtilTenantScope.tenantScope(c, async (tx) =>
       super.remove({ ...c, db: tx }, id),
     );
   }
 
   async getById<TSelection extends SelectedFields>(
-    c: IUserApp,
+    c: ITenantApp,
     id: TId,
     columns: TSelection,
   ) {
@@ -58,7 +58,7 @@ export abstract class ServiceBaseTenant<
   }
 
   async getAll<TSelection extends SelectedFields>(
-    c: IUserApp,
+    c: ITenantApp,
     query: { limit: number; page: number },
     columns: TSelection,
   ) {

--- a/src/common/utils/UtilTenantScope.ts
+++ b/src/common/utils/UtilTenantScope.ts
@@ -1,5 +1,5 @@
 import { ExtractTablesWithRelations, sql } from "drizzle-orm";
-import { IUserApp } from "../interfaces/IContextApp";
+import { ITenantApp } from "../interfaces/IContextApp";
 import {
   NodePgDatabase,
   NodePgQueryResultHKT,
@@ -17,7 +17,7 @@ type TTransaction =
 
 export class UtilTenantScope {
   static async tenantScope<T>(
-    c: IUserApp,
+    c: ITenantApp,
     callback: (tx: TTransaction) => Promise<T>,
   ): Promise<T> {
     return await c.db.transaction(async (tx) => {


### PR DESCRIPTION
## 🚀 What does this PR do?
[Explain the purpose of this PR. E.g., Added a new Redis cache service, fixed the RLS bypass bug in ServiceBaseTenant, etc.]

## 🔗 Related Issue
Fixes #

## 🛠 Type of Change
- [x] 🐞 Bug Fix (non-breaking change which fixes an issue)
- [ ] ✨ New Feature (non-breaking change which adds functionality)
- [x] ♻️ Refactoring (Code quality improvement, no new feature)
- [ ] 📖 Documentation Update

## 🏛️ Bedest Architecture Checklist (Critical)
- [ ] **Multi-tenancy:** If a new tenant-specific table was added, the service extends `ServiceBaseTenant` instead of `ServiceBase`.
- [ ] **Transaction & Context:** Database operations are wrapped in the correct scope (`UtilTenantScope.tenantScope` or `UtilTenantScope.systemScope`) and properly utilize the `IUserApp` / `IApp` contexts.
- [ ] **Strict Typing:** No `any` types were used. Type Narrowing is used for `unknown` errors. Drizzle's `InferInsertModel` and `InferSelectModel` are utilized correctly.
- [ ] **Schema Standards:** `UtilDbSchema.activeIndex` and `UtilDbSchema.tenantIsolationPolicy` are included for new tables where applicable.
- [ ] **Security & Guards:** Elysia routes are correctly protected using `RoleGuard` or `PlanGuard` macros where required.

## 🧪 Testing
- [x] Ran `bun test` and all existing PGlite tests passed successfully.
- [ ] Added new test cases for the specific feature or bug fix.

## 📋 Extra Checks
- [x] Code follows the existing formatting and linting rules (e.g., all `if` statements use curly braces `{}`).
- [ ] Updated `.env.example` and `VEnv` in `VCommon.ts` with any new environment variables required.
