### PR TITLE
feat: for self getter we added id field

### DIFF
--- a/src/features/storage/services/ServiceStorage.ts
+++ b/src/features/storage/services/ServiceStorage.ts
@@ -2,7 +2,7 @@ import { ServiceBaseTenant } from "@/common/services/ServiceBaseTenant";
 import { SStorage } from "../schemas/SStorage";
 
 import { status } from "elysia";
-import { IUserApp } from "@/common/interfaces/IContextApp";
+import { ITenantApp, IUserApp } from "@/common/interfaces/IContextApp";
 import StorageManager from "@/infrastructure/storage/StorageManager";
 
 class ServiceStorage extends ServiceBaseTenant<typeof SStorage, string> {
@@ -29,7 +29,7 @@ class ServiceStorage extends ServiceBaseTenant<typeof SStorage, string> {
     return { id: res.id, key: key };
   }
 
-  async get(c: IUserApp, id: string) {
+  async get(c: ITenantApp, id: string) {
     const fileRecord = await super.getById(c, id, {
       key: SStorage.key,
       mimeType: SStorage.mimeType,

--- a/src/features/tenant/routers/RouterTenant.test.ts
+++ b/src/features/tenant/routers/RouterTenant.test.ts
@@ -76,6 +76,7 @@ describe("RouterTenant", () => {
 
     expect(res.status).toBe(200);
     expect(res.data).toStrictEqual({
+      id: expect.any(String),
       name: "Test Tenant",
       domain: "test.com",
       email: "test@example.com",

--- a/src/features/tenant/routers/RouterTenant.ts
+++ b/src/features/tenant/routers/RouterTenant.ts
@@ -23,6 +23,7 @@ export const RouterTenant = new Elysia({
         userRuntime,
         userRuntime.tenantId,
         {
+          id: STenant.id,
           name: STenant.name,
           domain: STenant.domain,
           email: STenant.email,
@@ -38,6 +39,7 @@ export const RouterTenant = new Elysia({
     },
     {
       response: t.Object({
+        id: VId,
         name: VString,
         domain: VString,
         email: VEmail,


### PR DESCRIPTION
## 🚀 What does this PR do?
Id field added to tenant self getter for use storage getter without login. Also storage get context is changed IUserApp to ITenantApp.

## 🛠 Type of Change
- [ ] 🐞 Bug Fix (non-breaking change which fixes an issue)
- [ ] ✨ New Feature (non-breaking change which adds functionality)
- [x] ♻️ Refactoring (Code quality improvement, no new feature)
- [ ] 📖 Documentation Update

## 🏛️ Bedest Architecture Checklist (Critical)
- [ ] **Multi-tenancy:** If a new tenant-specific table was added, the service extends `ServiceBaseTenant` instead of `ServiceBase`.
- [ ] **Transaction & Context:** Database operations are wrapped in the correct scope (`UtilTenantScope.tenantScope` or `UtilTenantScope.systemScope`) and properly utilize the `IUserApp` / `IApp` contexts.
- [ ] **Strict Typing:** No `any` types were used. Type Narrowing is used for `unknown` errors. Drizzle's `InferInsertModel` and `InferSelectModel` are utilized correctly.
- [ ] **Schema Standards:** `UtilDbSchema.activeIndex` and `UtilDbSchema.tenantIsolationPolicy` are included for new tables where applicable.
- [ ] **Security & Guards:** Elysia routes are correctly protected using `RoleGuard` or `PlanGuard` macros where required.

## 🧪 Testing
- [x] Ran `bun test` and all existing PGlite tests passed successfully.
- [x] Added new test cases for the specific feature or bug fix.

## 📋 Extra Checks
- [x] Code follows the existing formatting and linting rules (e.g., all `if` statements use curly braces `{}`).
- [ ] Updated `.env.example` and `VEnv` in `VCommon.ts` with any new environment variables required.
