### PR TITLE
fix: little implementations for easier frontend implementations

### DIFF
--- a/src/features/tenant/routers/RouterTenant.test.ts
+++ b/src/features/tenant/routers/RouterTenant.test.ts
@@ -33,6 +33,7 @@ describe("RouterTenant", () => {
     expect(res.data!.data.length).toBeGreaterThanOrEqual(2);
     expect(res.data!.data).toStrictEqual([
       {
+        id: expect.any(String),
         country: "France",
         domain: "list.tenant.com",
         email: "list@tenant.com",
@@ -40,6 +41,7 @@ describe("RouterTenant", () => {
         name: "List Tenant",
       },
       {
+        id: expect.any(String),
         name: "Test Tenant",
         domain: "test.com",
         email: "test@example.com",

--- a/src/features/tenant/routers/RouterTenant.ts
+++ b/src/features/tenant/routers/RouterTenant.ts
@@ -180,6 +180,7 @@ export const RouterTenant = new Elysia({
           "/",
           async ({ query, userRuntime }) => {
             const res = await ServiceTenant.getAll(userRuntime, query, {
+              id: STenant.id,
               name: STenant.name,
               domain: STenant.domain,
               country: STenant.country,
@@ -193,6 +194,7 @@ export const RouterTenant = new Elysia({
             query: VQuery,
             response: UtilRouter.defPaginatedSchema(
               t.Object({
+                id: VId,
                 name: VString,
                 domain: VString,
                 country: VString,

--- a/src/features/user/routers/RouterUser.test.ts
+++ b/src/features/user/routers/RouterUser.test.ts
@@ -45,12 +45,16 @@ describe("RouterUser", () => {
     expect(res.status).toBe(200);
     expect(res.data!.data).toStrictEqual([
       {
+        id: expect.any(String),
+        tenantId: expect.any(String),
         createdAt: expect.any(Date),
         name: "List User",
         role: EUserRole.USER,
         avatarId: null,
       },
       {
+        id: expect.any(String),
+        tenantId: expect.any(String),
         createdAt: expect.any(Date),
         name: "Test User",
         role: EUserRole.SYSTEM,

--- a/src/features/user/routers/RouterUser.ts
+++ b/src/features/user/routers/RouterUser.ts
@@ -78,6 +78,8 @@ export const RouterUser = new Elysia({
             query: VQuery,
             response: UtilRouter.defPaginatedSchema(
               t.Object({
+                id: VId,
+                tenantId: VId,
                 name: VString,
                 role: t.Enum(EUserRole),
                 avatarId: t.Nullable(VId),

--- a/src/features/user/services/ServiceUser.ts
+++ b/src/features/user/services/ServiceUser.ts
@@ -44,6 +44,8 @@ class ServiceUser extends ServiceBaseTenant<typeof SUser, string> {
 
   async getAll(c: IUserApp, query: { limit: number; page: number }) {
     return super.getAll(c, query, {
+      id: SUser.id,
+      tenantId: SUser.tenantId,
       name: SUser.name,
       role: SUser.role,
       avatarId: SUser.avatarId,


### PR DESCRIPTION
## 🚀 What Does This PR Do?

<!-- Explain the purpose clearly. E.g., "Added cursor-based pagination to ServiceBase," "Fixed RLS bypass bug in UtilTenantScope," "Extracted X to bedest-core." -->

---

## 🔗 Related Issue

Fixes #

---

## 🛠 Type of Change

- [ ] 🐞 Bug Fix (non-breaking change which fixes an issue)
- [ ] ✨ New Feature (non-breaking change which adds functionality)
- [ ] ♻️ Refactoring (code quality improvement, no new feature)
- [ ] 💥 Breaking Change (fix or feature that would cause existing functionality to change)
- [ ] 📦 bedest-core (change that belongs to or affects the shared core package)
- [ ] 📖 Documentation Update

---

## 🏛️ Bedest Architecture Checklist

**Multi-tenancy & RLS**
- [ ] New tenant-specific tables have their service extending `ServiceBaseTenant` (not `ServiceBase`).
- [ ] New tables include `UtilDbSchema.tenantIsolationPolicy` and `.enableRLS()`.
- [ ] No raw DB query bypasses `UtilTenantScope.tenantScope` or `UtilTenantScope.systemScope`.

**Context & Typing**
- [ ] Service methods follow the `(c: IUserApp, ...)` or `(c: IApp, ...)` context pattern.
- [ ] No `any` types introduced. `unknown` errors are handled via type narrowing.
- [ ] Drizzle `InferInsertModel` / `InferSelectModel` are used correctly where applicable.

**Security & Guards**
- [ ] New routes are protected with `RoleGuard` or `PlanGuard` macros where required.
- [ ] No sensitive data (passwords, tokens) is logged or returned in responses.

**bedest-core boundary**
- [ ] Generic, domain-agnostic logic goes into `bedest-core`. Domain-specific logic stays in this repo.
- [ ] If `bedest-core` was changed, the version is bumped and the dependency here is updated.

---

## 🧪 Testing

- [ ] `bun test` passes with all existing PGlite tests green.
- [ ] New test cases added for the feature or bug fix.
- [ ] Edge cases covered: 404 for missing records, 403 for cross-tenant access, 401 for unauthenticated requests.

---

## 📋 Extra Checks

- [ ] Code follows existing formatting and linting rules (`bun run check` passes).
- [ ] `.env.example` and `VEnv` in `VCommon.ts` updated if new environment variables were added.
- [ ] No `console.log` left in production paths — use the `logger` from `infrastructure/logger`.
